### PR TITLE
Bug: Serialize datepart to JSON

### DIFF
--- a/GenDateTools.Test/DatePartTests.cs
+++ b/GenDateTools.Test/DatePartTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using Xunit;
 
 namespace GenDateTools.Test
@@ -529,6 +530,16 @@ namespace GenDateTools.Test
             var datePartExpected = new DatePart(expected);
 
             Assert.Equal(datePartExpected, datePartAdded);
+        }
+
+        [Fact]
+        public void DatePart_Serialize_ReturnsValidObject()
+        {
+            var datePart = new DatePart(2000, 1, 1);
+            var expected = "{\"Year\":2000,\"Month\":1,\"Day\":1}";
+            var actual = JsonConvert.SerializeObject(datePart);
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -8,6 +8,7 @@ namespace GenDateTools
     /// that the value is unknown.</para><para>Limitations: Uses rules from the Gregorian calendar, e.g. leap year. Year must be a number 
     /// from 0 to 9999, Month a number from 0 to 12 and Day a number between 0 and 31.</para>
     /// </summary>
+    [Serializable]
     public class DatePart : IEquatable<DatePart>, IComparable<DatePart>, IConvertible, ISerializable
     {
         internal const int MaxDaysInMonth = 31;


### PR DESCRIPTION
DatePart class is missing Serializable attribute that cause errors when using Newtonsoft.Json.