### PR TITLE
Made possible to use a shorter string than 8 numbers

### DIFF
--- a/GenDateTools.Test/DatePartTests.cs
+++ b/GenDateTools.Test/DatePartTests.cs
@@ -52,6 +52,12 @@ namespace GenDateTools.Test
         [InlineData("18900101", "18900101")]
         [InlineData("20180229", "20180229")]
         [InlineData("99991231", "99991231")]
+        [InlineData("1890010", "18900100")]
+        [InlineData("19000", "19000000")]
+        [InlineData("9999", "99990000")]
+        [InlineData("1", "00010000")]
+        [InlineData("0", "00000000")]
+        [InlineData("10000000JHDKJHDUIDANDSNAKJNDKAJLSDJA", "10000000")]
         public void DatePart_NewFromString_ValidDatePart(string dateString, string expected)
         {
             var datePart = new DatePart(dateString);

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -74,11 +74,18 @@ namespace GenDateTools
 
         /// <summary>
         /// Creates a DatePart object using a string date of the format <c>YYYYMMDD</c>. The values are split and passed to 
-        /// <see cref="DatePart.DatePart(int, int, int)"/>.
+        /// <see cref="DatePart.DatePart(int, int, int)"/>. If the string is shorter than 8 numbers, it converts the first 
+        /// 4 numbers to year, and the next 2 to month if it's 6 characters long.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <exception cref="FormatException"></exception>
+        /// <exception cref="OverflowException"></exception>
         public DatePart(string date)
-            : this(GenTools.GetSubString(date, 0, 4), GenTools.GetSubString(date, 4, 2), GenTools.GetSubString(date, 6, 2)) { }
+        {
+            Year = (date.Length >= 4) ? Convert.ToInt32(date.Substring(0, 4)) : Convert.ToInt32(date);
+            Month = (date.Length >= 6) ? Convert.ToInt32(date.Substring(4, 2)) : 0;
+            Day = (date.Length == 8) ? Convert.ToInt32(date.Substring(6, 2)) : 0;
+        }
 
         protected DatePart(SerializationInfo info, StreamingContext context)
         {


### PR DESCRIPTION
Removed the limitation that we couldn't use a string with just a year as parameter, but it had to be padded with '0' to get a length of 8 characters.