### PR TITLE
ReadOnly methods in GenDate, formatting and renaming

### DIFF
--- a/GenDateTools.Test/DatePartTests.cs
+++ b/GenDateTools.Test/DatePartTests.cs
@@ -16,7 +16,7 @@ namespace GenDateTools.Test
         [InlineData(99991231, "99991231")]
         public void DatePart_NewFromLong_ValidDatePart(long dateNum, string expected)
         {
-            var datePart = new DatePart(dateNum);
+            DatePart datePart = new DatePart(dateNum);
 
             Assert.Equal(expected, datePart.ToSortString());
         }
@@ -28,7 +28,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_NewFromYearMonthDay_ValidDatePart(int year, int month, int day, string expected)
         {
-            var datePart = new DatePart(year, month, day);
+            DatePart datePart = new DatePart(year, month, day);
 
             Assert.Equal(expected, datePart.ToSortString());
         }
@@ -41,7 +41,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 365, "99991231")]
         public void DatePart_NewFromYearDayOfYear_ValidDatePart(int year, int dayOfYear, string expected)
         {
-            var datePart = new DatePart(year, dayOfYear);
+            DatePart datePart = new DatePart(year, dayOfYear);
 
             Assert.Equal(expected, datePart.ToSortString());
         }
@@ -61,7 +61,7 @@ namespace GenDateTools.Test
         [InlineData("10000000JHDKJHDUIDANDSNAKJNDKAJLSDJA", "10000000")]
         public void DatePart_NewFromString_ValidDatePart(string dateString, string expected)
         {
-            var datePart = new DatePart(dateString);
+            DatePart datePart = new DatePart(dateString);
 
             Assert.Equal(expected, datePart.ToSortString());
         }
@@ -87,8 +87,8 @@ namespace GenDateTools.Test
         [InlineData("99991231", "99991230")]
         public void DatePart_NotEqualToOtherDatePartUsingOperator_ReturnsTrue(string date, string compareDate)
         {
-            var datePart1 = new DatePart(date);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(date);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 != datePart2);
         }
@@ -102,8 +102,8 @@ namespace GenDateTools.Test
         [InlineData("99991231", "99991231", 0)]
         public void DatePart_CompareToOtherDatePart_ReturnsTrue(string date, string compareDate, int expected)
         {
-            var datePart1 = new DatePart(date);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(date);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.Equal(expected, datePart1.CompareTo(datePart2));
         }
@@ -122,7 +122,7 @@ namespace GenDateTools.Test
         [InlineData("20170015", "15 2017")]
         public void DatePart_ToString_EqualString(string dateString, string expected)
         {
-            var datePart = new DatePart(dateString);
+            DatePart datePart = new DatePart(dateString);
 
             Assert.Equal(expected, datePart.ToString(CultureInfo.InvariantCulture));
         }
@@ -142,7 +142,7 @@ namespace GenDateTools.Test
         [InlineData(10000, false)]
         public void DatePart_IsLeapYear_Expected(int year, bool expected)
         {
-            var isValid = DatePart.IsLeapYear(year);
+            bool isValid = DatePart.IsLeapYear(year);
 
             Assert.Equal(expected, isValid);
         }
@@ -162,7 +162,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, true)]
         public void DatePart_YearMonthDay_IsValidDate(int year, int month, int day, bool expected)
         {
-            var isValid = DatePart.IsValidDate(year, month, day);
+            bool isValid = DatePart.IsValidDate(year, month, day);
 
             Assert.Equal(expected, isValid);
         }
@@ -178,7 +178,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, true)]
         public void DatePart_YearMonthDay_IsValidDateTime(int year, int month, int day, bool expected)
         {
-            var isValid = DatePart.IsValidDateTime(year, month, day);
+            bool isValid = DatePart.IsValidDateTime(year, month, day);
 
             Assert.Equal(expected, isValid);
         }
@@ -194,7 +194,7 @@ namespace GenDateTools.Test
         [InlineData(2020, 12, 31, 366)]
         public void DatePart_DayOfYear_IsValidDay(int year, int month, int day, int expected)
         {
-            var datePart = new DatePart(year, month, day);
+            DatePart datePart = new DatePart(year, month, day);
 
             Assert.Equal(expected, datePart.DayOfYear());
         }
@@ -210,7 +210,7 @@ namespace GenDateTools.Test
         [InlineData(2020, 12, 31)]
         public void DatePart_DaysInMonth_IsValidDays(int year, int month, int expected)
         {
-            var daysInMonth = DatePart.DaysInMonth(year, month);
+            int daysInMonth = DatePart.DaysInMonth(year, month);
 
             Assert.Equal(expected, daysInMonth);
         }
@@ -228,7 +228,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 365)]
         public void DatePart_DaysInYear_IsValidDays(int year, int expected)
         {
-            var daysInYear = DatePart.DaysInYear(year);
+            int daysInYear = DatePart.DaysInYear(year);
 
             Assert.Equal(expected, daysInYear);
         }
@@ -242,8 +242,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_Equals_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1.Equals(datePart2));
         }
@@ -257,8 +257,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_OperatorEqual_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 == datePart2);
         }
@@ -272,8 +272,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_OperatorNotEqual_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.False(datePart1 != datePart2);
         }
@@ -287,8 +287,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991230")]
         public void DatePart_OperatorLargerThan_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 > datePart2);
         }
@@ -302,8 +302,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 30, "99991231")]
         public void DatePart_OperatorLessThan_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 < datePart2);
         }
@@ -317,8 +317,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_OperatorLargerThanOrEqual_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 >= datePart2);
         }
@@ -332,8 +332,8 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, "99991231")]
         public void DatePart_OperatorLessThanOrEqual_ReturnsTrue(int year, int month, int day, string compareDate)
         {
-            var datePart1 = new DatePart(year, month, day);
-            var datePart2 = new DatePart(compareDate);
+            DatePart datePart1 = new DatePart(year, month, day);
+            DatePart datePart2 = new DatePart(compareDate);
 
             Assert.True(datePart1 <= datePart2);
         }
@@ -377,8 +377,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToInt32_IsEqualToType()
         {
-            var datePartConverted = Convert.ToInt32(new DatePart(20000101));
-            var expected = Convert.ToInt32(20000101);
+            int datePartConverted = Convert.ToInt32(new DatePart(20000101));
+            int expected = Convert.ToInt32(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<Int32>(datePartConverted);
@@ -387,8 +387,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToInt64_IsEqualToType()
         {
-            var datePartConverted = Convert.ToInt64(new DatePart(20000101));
-            var expected = Convert.ToInt64(20000101);
+            long datePartConverted = Convert.ToInt64(new DatePart(20000101));
+            long expected = Convert.ToInt64(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<Int64>(datePartConverted);
@@ -397,8 +397,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToUInt32_IsEqualToType()
         {
-            var datePartConverted = Convert.ToUInt32(new DatePart(20000101));
-            var expected = Convert.ToUInt32(20000101);
+            uint datePartConverted = Convert.ToUInt32(new DatePart(20000101));
+            uint expected = Convert.ToUInt32(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<UInt32>(datePartConverted);
@@ -407,8 +407,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToUInt64_IsEqualToType()
         {
-            var datePartConverted = Convert.ToUInt64(new DatePart(20000101));
-            var expected = Convert.ToUInt64(20000101);
+            ulong datePartConverted = Convert.ToUInt64(new DatePart(20000101));
+            ulong expected = Convert.ToUInt64(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<UInt64>(datePartConverted);
@@ -417,8 +417,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToSingle_IsEqualToType()
         {
-            var datePartConverted = Convert.ToSingle(new DatePart(20000101));
-            var expected = Convert.ToSingle(20000101);
+            float datePartConverted = Convert.ToSingle(new DatePart(20000101));
+            float expected = Convert.ToSingle(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<Single>(datePartConverted);
@@ -427,8 +427,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToDouble_IsEqualToType()
         {
-            var datePartConverted = Convert.ToDouble(new DatePart(20000101));
-            var expected = Convert.ToDouble(20000101);
+            double datePartConverted = Convert.ToDouble(new DatePart(20000101));
+            double expected = Convert.ToDouble(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<Double>(datePartConverted);
@@ -437,8 +437,8 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_ConvertToDecimal_IsEqualToType()
         {
-            var datePartConverted = Convert.ToDecimal(new DatePart(20000101));
-            var expected = Convert.ToDecimal(20000101);
+            decimal datePartConverted = Convert.ToDecimal(new DatePart(20000101));
+            decimal expected = Convert.ToDecimal(20000101);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<Decimal>(datePartConverted);
@@ -457,7 +457,7 @@ namespace GenDateTools.Test
         [InlineData("20170015", "15 2017")]
         public void DatePart_ConvertToString_IsStringAndEqual(string dateString, string expected)
         {
-            var datePartConverted = Convert.ToString(new DatePart(dateString));
+            string datePartConverted = Convert.ToString(new DatePart(dateString), CultureInfo.InvariantCulture);
 
             Assert.Equal(expected, datePartConverted);
             Assert.IsType<string>(datePartConverted);
@@ -476,9 +476,9 @@ namespace GenDateTools.Test
         [InlineData(99991231, -1, 99981231)]
         public void DatePart_AddYear_DatePartWithAddedYears(long datePartLong, int years, long expected)
         {
-            var datePart = new DatePart(datePartLong);
-            var datePartAdded = datePart.AddYears(years);
-            var datePartExpected = new DatePart(expected);
+            DatePart datePart = new DatePart(datePartLong);
+            DatePart datePartAdded = datePart.AddYears(years);
+            DatePart datePartExpected = new DatePart(expected);
 
             Assert.Equal(datePartExpected, datePartAdded);
         }
@@ -490,7 +490,7 @@ namespace GenDateTools.Test
         [InlineData(99991231, -100000000)]
         public void DatePart_AddYear_ThrowsArgumentOutOfRangeException(long datePartLong, int years)
         {
-            var datePart = new DatePart(datePartLong);
+            DatePart datePart = new DatePart(datePartLong);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => datePart.AddYears(years));
         }
@@ -509,9 +509,9 @@ namespace GenDateTools.Test
         [InlineData(99991231, -1, 99991130)]
         public void DatePart_AddMonths_DatePartWithAddedMonths(long datePartLong, int months, long expected)
         {
-            var datePart = new DatePart(datePartLong);
-            var datePartAdded = datePart.AddMonths(months);
-            var datePartExpected = new DatePart(expected);
+            DatePart datePart = new DatePart(datePartLong);
+            DatePart datePartAdded = datePart.AddMonths(months);
+            DatePart datePartExpected = new DatePart(expected);
 
             Assert.Equal(datePartExpected, datePartAdded);
         }
@@ -524,7 +524,7 @@ namespace GenDateTools.Test
         [InlineData(99991231, -100000000)]
         public void DatePart_AddMonths_ThrowsArgumentOutOfRangeException(long datePartLong, int years)
         {
-            var datePart = new DatePart(datePartLong);
+            DatePart datePart = new DatePart(datePartLong);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => datePart.AddMonths(years));
         }
@@ -540,9 +540,9 @@ namespace GenDateTools.Test
         [InlineData(20010101, -367, 19991231)]
         public void DatePart_AddDays_DatePartWithAddedDays(long datePartLong, int days, long expected)
         {
-            var datePart = new DatePart(datePartLong);
-            var datePartAdded = datePart.AddDays(days);
-            var datePartExpected = new DatePart(expected);
+            DatePart datePart = new DatePart(datePartLong);
+            DatePart datePartAdded = datePart.AddDays(days);
+            DatePart datePartExpected = new DatePart(expected);
 
             Assert.Equal(datePartExpected, datePartAdded);
         }
@@ -554,7 +554,7 @@ namespace GenDateTools.Test
         [InlineData(99991231, 1)]
         public void DatePart_AddDays_ThrowsArgumentOutOfRangeException(long datePartLong, int days)
         {
-            var datePart = new DatePart(datePartLong);
+            DatePart datePart = new DatePart(datePartLong);
 
             Assert.Throws<ArgumentOutOfRangeException>(() => datePart.AddDays(days));
         }
@@ -562,9 +562,9 @@ namespace GenDateTools.Test
         [Fact]
         public void DatePart_Serialize_ReturnsValidObject()
         {
-            var datePart = new DatePart(2000, 1, 1);
-            var expected = "{\"Year\":2000,\"Month\":1,\"Day\":1}";
-            var actual = JsonConvert.SerializeObject(datePart);
+            DatePart datePart = new DatePart(2000, 1, 1);
+            string expected = "{\"Year\":2000,\"Month\":1,\"Day\":1}";
+            string actual = JsonConvert.SerializeObject(datePart);
 
             Assert.Equal(expected, actual);
         }

--- a/GenDateTools.Test/DatePartTests.cs
+++ b/GenDateTools.Test/DatePartTests.cs
@@ -537,6 +537,7 @@ namespace GenDateTools.Test
         [InlineData(20000101, -1, 19991231)]
         [InlineData(20000301, -1, 20000229)]
         [InlineData(99991231, -1, 99991230)]
+        [InlineData(20010101, -367, 19991231)]
         public void DatePart_AddDays_DatePartWithAddedDays(long datePartLong, int days, long expected)
         {
             var datePart = new DatePart(datePartLong);

--- a/GenDateTools.Test/DatePartTests.cs
+++ b/GenDateTools.Test/DatePartTests.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace GenDateTools.Test
@@ -123,7 +124,7 @@ namespace GenDateTools.Test
         {
             var datePart = new DatePart(dateString);
 
-            Assert.Equal(expected, datePart.ToString());
+            Assert.Equal(expected, datePart.ToString(CultureInfo.InvariantCulture));
         }
 
         [Theory]

--- a/GenDateTools.Test/DateSpanTests.cs
+++ b/GenDateTools.Test/DateSpanTests.cs
@@ -13,7 +13,7 @@ namespace GenDateTools.Test
         [InlineData(9999999, 27397, 94)]
         public void DataSpan_NewFromDays_ReturnsDateSpan(int expectedTotalDays, int expectedYears, int expectedDays)
         {
-            var dateSpan = new DateSpan(expectedTotalDays);
+            DateSpan dateSpan = new DateSpan(expectedTotalDays);
 
             Assert.Equal(expectedYears, dateSpan.Years);
             Assert.Equal(expectedDays, dateSpan.Days);
@@ -29,7 +29,7 @@ namespace GenDateTools.Test
         [InlineData(9999999, 27397, 94)]
         public void DataSpan_NewFromYearsAndDays_ReturnsDateSpan(int expectedTotalDays, int expectedYears, int expectedDays)
         {
-            var dateSpan = new DateSpan(expectedYears, expectedDays);
+            DateSpan dateSpan = new DateSpan(expectedYears, expectedDays);
 
             Assert.Equal(expectedYears, dateSpan.Years);
             Assert.Equal(expectedDays, dateSpan.Days);
@@ -54,10 +54,10 @@ namespace GenDateTools.Test
         [InlineData(20120301, 20001001, 4169, 11, 152)]
         public void DataSpan_NewFromDateParts_ReturnsDateSpan(long datePartLong1, long datePartLong2, int expectedTotalDays, int expectedYears, int expectedDays)
         {
-            var datePart1 = new DatePart(datePartLong1);
-            var datePart2 = new DatePart(datePartLong2);
+            DatePart datePart1 = new DatePart(datePartLong1);
+            DatePart datePart2 = new DatePart(datePartLong2);
 
-            var dateSpan = new DateSpan(datePart1, datePart2);
+            DateSpan dateSpan = new DateSpan(datePart1, datePart2);
 
             Assert.Equal(expectedTotalDays, dateSpan.TotalDays);
             Assert.Equal(expectedYears, dateSpan.Years);
@@ -78,7 +78,7 @@ namespace GenDateTools.Test
         [InlineData(3650, "10 years")]
         public void DataSpan_ToString_ReturnsValidString(int totalDays, string expected)
         {
-            var dateSpan = new DateSpan(totalDays);
+            DateSpan dateSpan = new DateSpan(totalDays);
 
             Assert.Equal(expected, dateSpan.ToString());
         }

--- a/GenDateTools.Test/GedcomDateStringParserTests.cs
+++ b/GenDateTools.Test/GedcomDateStringParserTests.cs
@@ -25,8 +25,8 @@ namespace GenDateTools.Test
         [InlineData("(some text", "2")]
         public void GedcomDateStringParser_Parse_ReturnsValidGenDate(string dateString, string expected)
         {
-            var parser = new GedcomDateStringParser();
-            var genDate = new GenDate(parser, dateString);
+            GedcomDateStringParser parser = new GedcomDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -35,9 +35,9 @@ namespace GenDateTools.Test
         [InlineData("INT 1 JUL 1900 (some text)", "119000701819000701", "some text")]
         public void GedcomDateStringParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
-            var parser = new GedcomDateStringParser();
-            var genDate = new GenDate(parser, dateString);
-            var expectedGenDate = new GenDate(expected);
+            GedcomDateStringParser parser = new GedcomDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate.DateString, genDate.DateString);
             Assert.Equal(expectedPhrase, genDate.DatePhrase);

--- a/GenDateTools.Test/GedcomDateStringParserTests.cs
+++ b/GenDateTools.Test/GedcomDateStringParserTests.cs
@@ -33,7 +33,7 @@ namespace GenDateTools.Test
 
         [Theory]
         [InlineData("INT 1 JUL 1900 (some text)", "119000701819000701", "some text")]
-        public void GedcomDateStringParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
+        public void GedcomDateStringParser_ParseInterpretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
             GedcomDateStringParser parser = new GedcomDateStringParser();
             GenDate genDate = new GenDate(parser, dateString);

--- a/GenDateTools.Test/GenDateParserTests.cs
+++ b/GenDateTools.Test/GenDateParserTests.cs
@@ -33,7 +33,7 @@ namespace GenDateTools.Test
 
         [Theory]
         [InlineData("Int. 1 Jul 1900 (some text)", "119000701819000701", "some text")]
-        public void GenDateParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
+        public void GenDateParser_ParseInterpretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
             GenDateParser parser = new GenDateParser();
             GenDate genDate = new GenDate(parser, dateString);

--- a/GenDateTools.Test/GenDateParserTests.cs
+++ b/GenDateTools.Test/GenDateParserTests.cs
@@ -25,8 +25,8 @@ namespace GenDateTools.Test
         [InlineData("(some text", "2")]
         public void GenDateParser_Parse_ReturnsValidGenDate(string dateString, string expected)
         {
-            var parser = new GenDateParser();
-            var genDate = new GenDate(parser, dateString);
+            GenDateParser parser = new GenDateParser();
+            GenDate genDate = new GenDate(parser, dateString);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -35,9 +35,9 @@ namespace GenDateTools.Test
         [InlineData("Int. 1 Jul 1900 (some text)", "119000701819000701", "some text")]
         public void GenDateParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
-            var parser = new GenDateParser();
-            var genDate = new GenDate(parser, dateString);
-            var expectedGenDate = new GenDate(expected);
+            GenDateParser parser = new GenDateParser();
+            GenDate genDate = new GenDate(parser, dateString);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate.DateString, genDate.DateString);
             Assert.Equal(expectedPhrase, genDate.DatePhrase);

--- a/GenDateTools.Test/GenDateTests.cs
+++ b/GenDateTools.Test/GenDateTests.cs
@@ -14,7 +14,7 @@ namespace GenDateTools.Test
         [InlineData(100000000300000000, "100000000300000000")]
         public void GenDate_NewFromLong_ValidGenDate(long dateNum, string expected)
         {
-            var genDate = new GenDate(dateNum);
+            GenDate genDate = new GenDate(dateNum);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -28,7 +28,7 @@ namespace GenDateTools.Test
         [InlineData("100000000300000000", "100000000300000000")]
         public void GenDate_NewFromString_ValidGenDate(string dateString, string expected)
         {
-            var genDate = new GenDate(dateString);
+            GenDate genDate = new GenDate(dateString);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -42,8 +42,8 @@ namespace GenDateTools.Test
         [InlineData("20000229", "120000229220000229")]
         public void GenDate_NewFromDatePart_ValidGenDate(string datePartString, string expected)
         {
-            var datePart = new DatePart(datePartString);
-            var genDate = new GenDate(datePart);
+            DatePart datePart = new DatePart(datePartString);
+            GenDate genDate = new GenDate(datePart);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -57,8 +57,8 @@ namespace GenDateTools.Test
         [InlineData(4, "20000229", "120000229420000229")]
         public void GenDate_NewFromDateTypeAndDatePart_ValidGenDate(int dateType, string datePartString, string expected)
         {
-            var datePart = new DatePart(datePartString);
-            var genDate = new GenDate((GenDateType)dateType, datePart);
+            DatePart datePart = new DatePart(datePartString);
+            GenDate genDate = new GenDate((GenDateType)dateType, datePart);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -72,9 +72,9 @@ namespace GenDateTools.Test
         [InlineData(9, "99991231", "99991231", "199991231999991231")]
         public void GenDate_NewFromDateTypeFromDatePartAndToDatePart_ValidGenDate(int dateType, string fromDatePartStr, string toDatePartStr, string expected)
         {
-            var fromDatePart = new DatePart(fromDatePartStr);
-            var toDatePart = new DatePart(toDatePartStr);
-            var genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart);
+            DatePart fromDatePart = new DatePart(fromDatePartStr);
+            DatePart toDatePart = new DatePart(toDatePartStr);
+            GenDate genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -88,11 +88,11 @@ namespace GenDateTools.Test
         [InlineData(9, "99991231", "99991231", true, "199991231999991231")]
         public void GenDate_NewFromDateTypeFromDatePartAndToDatePartIsValid_ValidGenDate(int dateType, string fromDatePartStr, string toDatePartStr, bool isValid, string expected)
         {
-            var fromDatePart = new DatePart(fromDatePartStr);
-            var toDatePart = new DatePart(toDatePartStr);
+            DatePart fromDatePart = new DatePart(fromDatePartStr);
+            DatePart toDatePart = new DatePart(toDatePartStr);
 
-            var genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart, isValid);
-            var expectedGenDate = new GenDate(expected);
+            GenDate genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart, isValid);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate, genDate);
         }
@@ -106,12 +106,12 @@ namespace GenDateTools.Test
         [InlineData(9, "99991231", "99991231", true, "199991231999991231")]
         public void GenDate_NewFromAll_ValidGenDate(int dateType, string fromDatePartStr, string toDatePartStr, bool isValid, string expected)
         {
-            var fromDatePart = new DatePart(fromDatePartStr);
-            var toDatePart = new DatePart(toDatePartStr);
-            var datePhrase = "Testing a pretty long string";
+            DatePart fromDatePart = new DatePart(fromDatePartStr);
+            DatePart toDatePart = new DatePart(toDatePartStr);
+            string datePhrase = "Testing a pretty long string";
 
-            var genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart, datePhrase, isValid);
-            var expectedGenDate = new GenDate(expected);
+            GenDate genDate = new GenDate((GenDateType)dateType, fromDatePart, toDatePart, datePhrase, isValid);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate.DateLong, genDate.DateLong);
             Assert.Equal(expectedGenDate.DateString, genDate.DateString);
@@ -123,9 +123,9 @@ namespace GenDateTools.Test
         [Fact]
         public void GenDate_CallWithToDatePartEqualNull_ShouldReturnValid()
         {
-            var datePhrase = "Testing a pretty long string";
-            var genDate = new GenDate(GenDateType.Before, new DatePart("19000101"), null, datePhrase, true);
-            var expected = new GenDate("119000101119000101");
+            string datePhrase = "Testing a pretty long string";
+            GenDate genDate = new GenDate(GenDateType.Before, new DatePart("19000101"), null, datePhrase, true);
+            GenDate expected = new GenDate("119000101119000101");
 
             Assert.Equal(expected.DateLong, genDate.DateLong);
             Assert.Equal(expected.DateString, genDate.DateString);
@@ -137,8 +137,8 @@ namespace GenDateTools.Test
         [Fact]
         public void GenDate_CallWithIsValidEqualFalse_ShouldReturnValid()
         {
-            var genDate = new GenDate(GenDateType.Before, new DatePart("19000101"), new DatePart("19000101"), "", false);
-            var expected = new GenDate("119000101119000101");
+            GenDate genDate = new GenDate(GenDateType.Before, new DatePart("19000101"), new DatePart("19000101"), "", false);
+            GenDate expected = new GenDate("119000101119000101");
 
             Assert.Equal(expected.DateLong, genDate.DateLong);
             Assert.Equal(expected.DateString, genDate.DateString);
@@ -157,7 +157,7 @@ namespace GenDateTools.Test
         [InlineData(199991231999991231)]
         public void GenDate_GetDateLong_ValidGenDate(long dateNum)
         {
-            var genDate = new GenDate(dateNum);
+            GenDate genDate = new GenDate(dateNum);
 
             Assert.Equal(dateNum, genDate.DateLong);
         }
@@ -178,7 +178,7 @@ namespace GenDateTools.Test
         [InlineData("108600000609100000", "Bet. 860 - 910")]
         public void Gendate_ToString_EqualString(string dateString, string expected)
         {
-            var genDate = new GenDate(dateString);
+            GenDate genDate = new GenDate(dateString);
 
             Assert.Equal(expected, genDate.ToString());
         }
@@ -192,8 +192,8 @@ namespace GenDateTools.Test
         [InlineData(100000000300000000, "100000000300000000")]
         public void GenDate_Equals_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1.Equals(genDate2));
         }
@@ -207,8 +207,8 @@ namespace GenDateTools.Test
         [InlineData(100000000300000000, "100000000300000000")]
         public void GenDate_OperatorEqual_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1 == genDate2);
         }
@@ -222,8 +222,8 @@ namespace GenDateTools.Test
         [InlineData(100000000300000000, "100000000300000000")]
         public void GenDate_OperatorNotEqual_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.False(genDate1 != genDate2);
         }
@@ -237,8 +237,8 @@ namespace GenDateTools.Test
         [InlineData(100000000300000000, "100000000200000000")]
         public void GenDate_OperatorLargerThan_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1 > genDate2);
         }
@@ -252,8 +252,8 @@ namespace GenDateTools.Test
         [InlineData(100000000200000000, "100000000300000000")]
         public void GenDate_OperatorLessThan_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1 < genDate2);
         }
@@ -267,8 +267,8 @@ namespace GenDateTools.Test
         [InlineData(120000229220000229, "120000229220000229")]
         public void GenDate_OperatorLargerThanOrEqual_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1 >= genDate2);
         }
@@ -282,8 +282,8 @@ namespace GenDateTools.Test
         [InlineData(120000229220000229, "120000229220000229")]
         public void GenDate_OperatorLessThanOrEqual_ReturnsTrue(long dateNum, string compareDate)
         {
-            var genDate1 = new GenDate(dateNum);
-            var genDate2 = new GenDate(compareDate);
+            GenDate genDate1 = new GenDate(dateNum);
+            GenDate genDate2 = new GenDate(compareDate);
 
             Assert.True(genDate1 <= genDate2);
         }
@@ -300,7 +300,7 @@ namespace GenDateTools.Test
         [InlineData(119000101719001200, 19000101)]
         public void GenDate_From_ReturnsInt(long dateNum, int expected)
         {
-            var genDate = new GenDate(dateNum);
+            GenDate genDate = new GenDate(dateNum);
 
             Assert.Equal(expected, genDate.From);
         }
@@ -317,7 +317,7 @@ namespace GenDateTools.Test
         [InlineData(119000101719001200, 19001231)]
         public void GenDate_To_ReturnsInt(long dateNum, int expected)
         {
-            var genDate = new GenDate(dateNum);
+            GenDate genDate = new GenDate(dateNum);
 
             Assert.Equal(expected, genDate.To);
         }
@@ -325,7 +325,7 @@ namespace GenDateTools.Test
         [Fact]
         public void GenDate_GetDateRangeStrategy_ReturnsDefault()
         {
-            var actual = DateRangeStrategy.Strategy;
+            DateRangeStrategy actual = DateRangeStrategy.Strategy;
 
             Assert.IsAssignableFrom<DateRangeStrategy>(actual);
         }
@@ -333,7 +333,7 @@ namespace GenDateTools.Test
         [Fact]
         public void GenDate_SetDateRangeStrategy_ReturnsChanged()
         {
-            var expected = new DateRangeStrategy
+            DateRangeStrategy expected = new DateRangeStrategy
             {
                 AfterYears = 10,
                 BeforeYears = 10,
@@ -343,7 +343,7 @@ namespace GenDateTools.Test
             };
             DateRangeStrategy.Strategy = expected;
 
-            var actual = DateRangeStrategy.Strategy;
+            DateRangeStrategy actual = DateRangeStrategy.Strategy;
 
             Assert.Equal(expected.AboutYearsAfter, actual.AboutYearsAfter);
             Assert.Equal(expected.AboutYearsBefore, actual.AboutYearsBefore);
@@ -358,14 +358,16 @@ namespace GenDateTools.Test
         [InlineData(99991231, 99991200)]
         public void GenDate_From_DateRangeStrategyUseRelaxedDates_ReturnsZeroDays(int input, int expected)
         {
-            var genDate = new GenDate(new DatePart(input));
-            genDate.DateRangeStrategy = new DateRangeStrategy
+            GenDate genDate = new GenDate(new DatePart(input))
             {
-                AfterYears = 10,
-                BeforeYears = 10,
-                AboutYearsAfter = 0,
-                AboutYearsBefore = 0,
-                UseRelaxedDates = true,
+                DateRangeStrategy = new DateRangeStrategy
+                {
+                    AfterYears = 10,
+                    BeforeYears = 10,
+                    AboutYearsAfter = 0,
+                    AboutYearsBefore = 0,
+                    UseRelaxedDates = true,
+                }
             };
 
             Assert.Equal(expected, genDate.From);
@@ -378,14 +380,16 @@ namespace GenDateTools.Test
         [InlineData(99991130, 99991200)]
         public void GenDate_To_DateRangeStrategyUseRelaxedDates_ReturnsNextMonthZeroDays(int input, int expected)
         {
-            var genDate = new GenDate(new DatePart(input));
-            genDate.DateRangeStrategy = new DateRangeStrategy
+            GenDate genDate = new GenDate(new DatePart(input))
             {
-                AfterYears = 10,
-                BeforeYears = 10,
-                AboutYearsAfter = 0,
-                AboutYearsBefore = 0,
-                UseRelaxedDates = true,
+                DateRangeStrategy = new DateRangeStrategy
+                {
+                    AfterYears = 10,
+                    BeforeYears = 10,
+                    AboutYearsAfter = 0,
+                    AboutYearsBefore = 0,
+                    UseRelaxedDates = true,
+                }
             };
 
             Assert.Equal(expected, genDate.To);
@@ -397,14 +401,16 @@ namespace GenDateTools.Test
         [InlineData(20040229, 20030229)]
         public void GenDate_From_DateRangeStrategyAboutYears_ReturnsYearBefore(int input, int expected)
         {
-            var genDate = new GenDate(GenDateType.About, new DatePart(input));
-            genDate.DateRangeStrategy = new DateRangeStrategy
+            GenDate genDate = new GenDate(GenDateType.About, new DatePart(input))
             {
-                AfterYears = 0,
-                BeforeYears = 0,
-                AboutYearsAfter = 0,
-                AboutYearsBefore = 1,
-                UseRelaxedDates = false,
+                DateRangeStrategy = new DateRangeStrategy
+                {
+                    AfterYears = 0,
+                    BeforeYears = 0,
+                    AboutYearsAfter = 0,
+                    AboutYearsBefore = 1,
+                    UseRelaxedDates = false,
+                }
             };
 
             Assert.Equal(expected, genDate.From);
@@ -417,14 +423,16 @@ namespace GenDateTools.Test
         [InlineData(99981231, 99991231)]
         public void GenDate_To_DateRangeStrategyAboutYears_ReturnsYearAfter(int input, int expected)
         {
-            var genDate = new GenDate(GenDateType.About, new DatePart(input));
-            genDate.DateRangeStrategy = new DateRangeStrategy
+            GenDate genDate = new GenDate(GenDateType.About, new DatePart(input))
             {
-                AfterYears = 0,
-                BeforeYears = 0,
-                AboutYearsAfter = 1,
-                AboutYearsBefore = 0,
-                UseRelaxedDates = false,
+                DateRangeStrategy = new DateRangeStrategy
+                {
+                    AfterYears = 0,
+                    BeforeYears = 0,
+                    AboutYearsAfter = 1,
+                    AboutYearsBefore = 0,
+                    UseRelaxedDates = false,
+                }
             };
 
             Assert.Equal(expected, genDate.To);

--- a/GenDateTools.Test/GenDateTests.cs
+++ b/GenDateTools.Test/GenDateTests.cs
@@ -176,7 +176,7 @@ namespace GenDateTools.Test
         [InlineData("100000001100000001", "Bef. 01")]
         [InlineData("100500000600700000", "Bet. 50 - 70")]
         [InlineData("108600000609100000", "Bet. 860 - 910")]
-        public void Gendate_ToString_EqualString(string dateString, string expected)
+        public void GenDate_ToString_EqualString(string dateString, string expected)
         {
             GenDate genDate = new GenDate(dateString);
 

--- a/GenDateTools.Test/GenExtensionTests.cs
+++ b/GenDateTools.Test/GenExtensionTests.cs
@@ -35,7 +35,7 @@ namespace GenDateTools.Test
         [InlineData("99991231", "99991231")]
         public void GenExtension_ToSortString_ReturnSortString(string datePartStr, string expected)
         {
-            var datePart = new DatePart(datePartStr);
+            DatePart datePart = new DatePart(datePartStr);
 
             Assert.Equal(expected, datePart.ToSortString());
         }
@@ -47,7 +47,7 @@ namespace GenDateTools.Test
         [InlineData("99991231", "9999-12-31")]
         public void GenExtension_ToIsoString_ReturnIsoString(string datePartStr, string expected)
         {
-            var datePart = new DatePart(datePartStr);
+            DatePart datePart = new DatePart(datePartStr);
 
             Assert.Equal(expected, datePart.ToIsoString());
         }
@@ -59,7 +59,7 @@ namespace GenDateTools.Test
         [InlineData("99991231", "31 Dec 9999")]
         public void GenExtension_DatePartToGenString_ReturnGenString(string datePartStr, string expected)
         {
-            var datePart = new DatePart(datePartStr);
+            DatePart datePart = new DatePart(datePartStr);
 
             Assert.Equal(expected, datePart.ToGenString());
         }
@@ -80,7 +80,7 @@ namespace GenDateTools.Test
         [InlineData("108600000609100000", "Bet. 860 - 910")]
         public void GenExtension_GenDateToGenString_ReturnGenString(string genDateStr, string expected)
         {
-            var genDate = new GenDate(genDateStr);
+            GenDate genDate = new GenDate(genDateStr);
 
             Assert.Equal(expected, genDate.ToGenString());
         }
@@ -111,7 +111,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, true)]
         public void GenExtension_YearMonthDay_IsValidDate(int year, int month, int day, bool expected)
         {
-            var datePart = new DatePart(year, month, day);
+            DatePart datePart = new DatePart(year, month, day);
 
             Assert.Equal(expected, datePart.IsValidDate());
             Assert.IsType<DatePart>(datePart);
@@ -127,7 +127,7 @@ namespace GenDateTools.Test
         [InlineData(9999, 12, 31, true)]
         public void GenExtension_YearMonthDay_IsValidDateTime(int year, int month, int day, bool expected)
         {
-            var datePart = new DatePart(year, month, day);
+            DatePart datePart = new DatePart(year, month, day);
 
             Assert.Equal(expected, datePart.IsValidDateTime());
             Assert.IsType<DatePart>(datePart);

--- a/GenDateTools.Test/LegacyDateStringParserTests.cs
+++ b/GenDateTools.Test/LegacyDateStringParserTests.cs
@@ -30,7 +30,7 @@ namespace GenDateTools.Test
 
         [Theory]
         [InlineData(@":00000183100000000\Langfredag? 1831", "118310000218310000", "Langfredag? 1831")]
-        public void LegacyDateStringParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
+        public void LegacyDateStringParser_ParseInterpretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
             LegacyDateStringParser parser = new LegacyDateStringParser();
             GenDate genDate = new GenDate(parser, dateString);

--- a/GenDateTools.Test/LegacyDateStringParserTests.cs
+++ b/GenDateTools.Test/LegacyDateStringParserTests.cs
@@ -22,8 +22,8 @@ namespace GenDateTools.Test
         [InlineData(@":00000183100000000\Langfredag? 1831", "118310000218310000")]
         public void LegacyDateStringParser_Parse_ReturnsValidGenDate(string dateString, string expected)
         {
-            var parser = new LegacyDateStringParser();
-            var genDate = new GenDate(parser, dateString);
+            LegacyDateStringParser parser = new LegacyDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
 
             Assert.Equal(expected, genDate.DateString);
         }
@@ -32,9 +32,9 @@ namespace GenDateTools.Test
         [InlineData(@":00000183100000000\Langfredag? 1831", "118310000218310000", "Langfredag? 1831")]
         public void LegacyDateStringParser_ParseIntepretedWithText_ReturnsValidGenDate(string dateString, string expected, string expectedPhrase)
         {
-            var parser = new LegacyDateStringParser();
-            var genDate = new GenDate(parser, dateString);
-            var expectedGenDate = new GenDate(expected);
+            LegacyDateStringParser parser = new LegacyDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate.DateString, genDate.DateString);
             Assert.Equal(expectedPhrase, genDate.DatePhrase);

--- a/GenDateTools.Test/RootsMagicDateStringParserTests.cs
+++ b/GenDateTools.Test/RootsMagicDateStringParserTests.cs
@@ -24,9 +24,9 @@ namespace GenDateTools.Test
         [InlineData("D.+20011105.L+00000000..", "120011105420011105")]
         public void RootsMagicDateStringParser_Parse_ReturnsValidGenDate(string dateString, string expected)
         {
-            var parser = new RootsMagicDateStringParser();
-            var genDate = new GenDate(parser, dateString);
-            var expectedGenDate = new GenDate(expected);
+            RootsMagicDateStringParser parser = new RootsMagicDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
+            GenDate expectedGenDate = new GenDate(expected);
 
             Assert.Equal(expectedGenDate, genDate);
         }
@@ -37,8 +37,8 @@ namespace GenDateTools.Test
         [InlineData(".", "")]
         public void RootsMagicDateStringParser_Parse_ReturnsInvalidGenDate(string dateString, string expected)
         {
-            var parser = new RootsMagicDateStringParser();
-            var genDate = new GenDate(parser, dateString);
+            RootsMagicDateStringParser parser = new RootsMagicDateStringParser();
+            GenDate genDate = new GenDate(parser, dateString);
 
             Assert.Equal(expected, genDate.DatePhrase);
             Assert.Equal(expected, genDate.ToString());

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -103,7 +103,7 @@ namespace GenDateTools
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             Year = Convert.ToInt32(info.GetString("Year"));
@@ -262,7 +262,6 @@ namespace GenDateTools
             }
             else
             {
-                calcDayOfYear = calcDayOfYear > 0 ? 0 - calcDayOfYear : calcDayOfYear;
                 while (calcDayOfYear < 1)
                 {
                     year--;

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -47,11 +47,21 @@ namespace GenDateTools
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public DatePart(int year, int month, int day)
         {
-            if (!(year >= _minYear && year <= _maxYear && month >= _minMonthInYear && month <= _maxMonthInYear && day >= _minDaysInMonth && day <= _maxDaysInMonth))
+            if (year < _minYear || year > _maxYear)
             {
-                throw new ArgumentOutOfRangeException("Arguments out of range");
+                throw new ArgumentOutOfRangeException(nameof(year), "Arguments out of range");
             }
 
+            if (month < _minMonthInYear || month > _maxMonthInYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(month), "Arguments out of range");
+            }
+            
+            if (day < _minDaysInMonth || day > _maxDaysInMonth)
+            {
+                throw new ArgumentOutOfRangeException(nameof(day), "Arguments out of range");
+            }
+            
             Year = year;
             Month = month;
             Day = day;

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -21,8 +21,8 @@ namespace GenDateTools
         public static readonly DatePart MinValue = new DatePart(_minYear, _minMonthInYear, _minDaysInMonth);
         public static readonly DatePart MaxValue = new DatePart(_maxYear, _maxMonthInYear, _maxDaysInMonth);
 
-        private static readonly int[] _daysToMonth365 = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 };
-        private static readonly int[] _daysToMonth366 = { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 };
+        private static readonly int[] _daysToMonth365 = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+        private static readonly int[] _daysToMonth366 = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
 
         public int Year { get; }
         public int Month { get; }
@@ -69,24 +69,28 @@ namespace GenDateTools
 
         /// <summary>
         /// Creates a DatePart object using 3 string parameters; year, month and day. 
-        /// See also: <seealso cref="DatePart.DatePart(int, int, int)"/>
+        /// See also: <seealso cref="DatePart(int, int, int)"/>
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public DatePart(string year, string month, string day)
-            : this(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day)) { }
+            : this(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day))
+        {
+        }
 
         /// <summary>
         /// Creates a DatePart object using a numeric date as a parameter. It is a long between 0 and 99991231, which is made with the formula:
         /// <para><c>Year * 10000 + Month * 100 + Day</c></para>
-        /// <para>These values are recreated from the long value, and passed to <see cref="DatePart.DatePart(int, int, int)"/>.</para>
+        /// <para>These values are recreated from the long value, and passed to <see cref="DatePart(int, int, int)"/>.</para>
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public DatePart(long date)
-            : this((int)date / 10000, (int)(date / 100) % 100, (int)date % 100) { }
+            : this((int)date / 10000, (int)(date / 100) % 100, (int)date % 100)
+        {
+        }
 
         /// <summary>
         /// Creates a DatePart object using a string date of the format <c>YYYYMMDD</c>. The values are split and passed to 
-        /// <see cref="DatePart.DatePart(int, int, int)"/>. If the string is shorter than 8 numbers, it converts the first 
+        /// <see cref="DatePart(int, int, int)"/>. If the string is shorter than 8 numbers, it converts the first 
         /// 4 numbers to year, and the next 2 to month if it's 6 characters long.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -194,9 +198,10 @@ namespace GenDateTools
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public DatePart AddYears(int years)
         {
-            if (((Year + years) > _maxYear) || ((Year + years) < _minYear))
+            if ((Year + years) > _maxYear || (Year + years) < _minYear)
             {
-                throw new ArgumentOutOfRangeException(nameof(years), years, $"Resulting year must be between {_minYear} and {_maxYear}.");
+                throw new ArgumentOutOfRangeException(nameof(years), years,
+                    $"Resulting year must be between {_minYear} and {_maxYear}.");
             }
 
             return new DatePart(Year + years, Month, Day);
@@ -224,7 +229,8 @@ namespace GenDateTools
 
             if (year < _minYear || year > _maxYear)
             {
-                throw new ArgumentOutOfRangeException(nameof(months), months, $"Resulting year must be between {_minYear} and {_maxYear}.");
+                throw new ArgumentOutOfRangeException(nameof(months), months,
+                    $"Resulting year must be between {_minYear} and {_maxYear}.");
             }
 
             int daysInMonth = DaysInMonth(year, mon);
@@ -256,7 +262,8 @@ namespace GenDateTools
 
                     if (year > _maxYear)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(days), $"Resulting year must be between {_minYear} and {_maxYear}.");
+                        throw new ArgumentOutOfRangeException(nameof(days),
+                            $"Resulting year must be between {_minYear} and {_maxYear}.");
                     }
                 }
             }
@@ -268,7 +275,8 @@ namespace GenDateTools
 
                     if (year < _minYear)
                     {
-                        throw new ArgumentOutOfRangeException(nameof(days), $"Resulting year must be between {_minYear} and {_maxYear}.");
+                        throw new ArgumentOutOfRangeException(nameof(days),
+                            $"Resulting year must be between {_minYear} and {_maxYear}.");
                     }
 
                     calcDayOfYear += DaysInYear(year);
@@ -434,12 +442,7 @@ namespace GenDateTools
                 return false;
             }
 
-            if (GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            return Equals((DatePart)obj);
+            return GetType() == obj.GetType() && Equals((DatePart)obj);
         }
 
         public override int GetHashCode()
@@ -470,6 +473,7 @@ namespace GenDateTools
         }
 
         #region IConvertible GetTypeCode and Methods
+
         public TypeCode GetTypeCode()
         {
             return TypeCode.Object;
@@ -554,6 +558,7 @@ namespace GenDateTools
         {
             return Convert.ToUInt64(CompareValue(this));
         }
+
         #endregion
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -576,8 +581,8 @@ namespace GenDateTools
         internal static DatePart GetMaxRange(DatePart datePart)
         {
             return new DatePart(datePart.Year,
-                    datePart.Month != 0 ? datePart.Month : _maxMonthInYear,
-                    datePart.Day != 0 ? datePart.Day : DaysInMonth(datePart.Year, datePart.Month));
+                datePart.Month != 0 ? datePart.Month : _maxMonthInYear,
+                datePart.Day != 0 ? datePart.Day : DaysInMonth(datePart.Year, datePart.Month));
         }
     }
 }

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -24,9 +24,9 @@ namespace GenDateTools
         private static readonly int[] _daysToMonth365 = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 };
         private static readonly int[] _daysToMonth366 = { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 };
 
-        public int Year { get; set; }
-        public int Month { get; set; }
-        public int Day { get; set; }
+        public int Year { get; }
+        public int Month { get; }
+        public int Day { get; }
 
         /// <summary>
         /// Creates a DatePart object without parameters, with only unknown values for Year, Month and Day.

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -572,7 +572,7 @@ namespace GenDateTools
         {
             if (info == null)
             {
-                throw new ArgumentNullException("info");
+                throw new ArgumentNullException(nameof(info));
             }
 
             GetObjectData(info, context);

--- a/GenDateTools/Models/DatePart.cs
+++ b/GenDateTools/Models/DatePart.cs
@@ -127,7 +127,7 @@ namespace GenDateTools
                 throw new ArgumentOutOfRangeException(nameof(dayOfYear), dayOfYear, "Arguments out of range");
             }
 
-            var month = 0;
+            int month = 0;
             int[] daysInMonth = IsLeapYear(year) ? _daysToMonth366 : _daysToMonth365;
 
             while (dayOfYear > daysInMonth[month])
@@ -150,7 +150,7 @@ namespace GenDateTools
         public int DayOfYear()
         {
             int[] daysInMonth = IsLeapYear(Year) ? _daysToMonth366 : _daysToMonth365;
-            var prevMonth = Month > 0 ? Month - 1 : 0;
+            int prevMonth = Month > 0 ? Month - 1 : 0;
 
             return daysInMonth[prevMonth] + Day;
         }
@@ -210,7 +210,7 @@ namespace GenDateTools
         {
             int year = Year, mon = Month, day = Day;
 
-            var calcMonth = mon - 1 + months;
+            int calcMonth = mon - 1 + months;
             if (calcMonth >= 0)
             {
                 mon = (calcMonth % 12) + 1;
@@ -227,7 +227,7 @@ namespace GenDateTools
                 throw new ArgumentOutOfRangeException(nameof(months), months, $"Resulting year must be between {_minYear} and {_maxYear}.");
             }
 
-            var daysInMonth = DaysInMonth(year, mon);
+            int daysInMonth = DaysInMonth(year, mon);
             if (day > daysInMonth)
             {
                 day = daysInMonth;
@@ -244,8 +244,8 @@ namespace GenDateTools
         {
             int year = Year;
 
-            var dayOfYear = DayOfYear();
-            var calcDayOfYear = dayOfYear + days;
+            int dayOfYear = DayOfYear();
+            int calcDayOfYear = dayOfYear + days;
 
             if (calcDayOfYear > 0)
             {
@@ -334,15 +334,15 @@ namespace GenDateTools
         /// </summary>
         public static DatePart Today()
         {
-            var dateTime = DateTime.Today;
+            DateTime dateTime = DateTime.Today;
 
             return new DatePart(dateTime.Year, dateTime.Month, dateTime.Day);
         }
 
         public int CompareTo(DatePart other)
         {
-            var sortDate = CompareValue(this);
-            var sortDateOther = CompareValue(other);
+            int sortDate = CompareValue(this);
+            int sortDateOther = CompareValue(other);
 
             return sortDate.CompareTo(sortDateOther);
         }
@@ -446,7 +446,7 @@ namespace GenDateTools
         {
             unchecked
             {
-                var hashCode = Year.GetHashCode();
+                int hashCode = Year.GetHashCode();
                 hashCode = (hashCode * 397) ^ Month.GetHashCode();
                 hashCode = (hashCode * 397) ^ Day.GetHashCode();
                 return hashCode;
@@ -458,9 +458,9 @@ namespace GenDateTools
         /// </summary>
         public override string ToString()
         {
-            var output = Day > 0 && Day <= _maxDaysInMonth ? Day.ToString().PadLeft(2, '0') : "";
-            var month = Month > 0 && Month <= _maxMonthInYear ? GenTools.MonthName(Month) : "";
-            var year = Year > 0 ? Year.ToString() : "";
+            string output = Day > 0 && Day <= _maxDaysInMonth ? Day.ToString().PadLeft(2, '0') : "";
+            string month = Month > 0 && Month <= _maxMonthInYear ? GenTools.MonthName(Month) : "";
+            string year = Year > 0 ? Year.ToString() : "";
 
             output += output != "" && month != "" ? " " : "";
             output += month;

--- a/GenDateTools/Models/DateSpan.cs
+++ b/GenDateTools/Models/DateSpan.cs
@@ -28,9 +28,7 @@ namespace GenDateTools
         {
             if (datePart1 > datePart2)
             {
-                var datePartTemp = datePart1;
-                datePart1 = datePart2;
-                datePart2 = datePartTemp;
+                (datePart1, datePart2) = (datePart2, datePart1);
             }
 
             _years = 0;

--- a/GenDateTools/Models/DateSpan.cs
+++ b/GenDateTools/Models/DateSpan.cs
@@ -35,7 +35,7 @@ namespace GenDateTools
             _totalDays = DatePart.DaysInYear(datePart1.Year) - datePart1.DayOfYear() - (DatePart.DaysInYear(datePart2.Year) - datePart2.DayOfYear());
             _days = datePart2.DayOfYear() - datePart1.DayOfYear();
 
-            var processYear = datePart1.Year;
+            int processYear = datePart1.Year;
 
             while (processYear < datePart2.Year)
             {
@@ -115,7 +115,7 @@ namespace GenDateTools
         {
             unchecked
             {
-                var hashCode = TotalDays.GetHashCode();
+                int hashCode = TotalDays.GetHashCode();
                 hashCode = (hashCode * 397) ^ Years.GetHashCode();
                 hashCode = (hashCode * 397) ^ Days.GetHashCode();
                 return hashCode;
@@ -124,10 +124,10 @@ namespace GenDateTools
 
         public override string ToString()
         {
-            var years = $"{Years} year{(Years > 1 ? "s" : "")}";
-            var days = $"{Days} day{(Days == 0 || Days > 1 ? "s" : "")}";
+            string years = $"{Years} year{(Years > 1 ? "s" : "")}";
+            string days = $"{Days} day{(Days == 0 || Days > 1 ? "s" : "")}";
 
-            var output = Years > 0 ? years : "";
+            string output = Years > 0 ? years : "";
             output += (Years > 0 && Days > 0) ? " and " : "";
 
             return output + ((Days > 0 || Years == 0) ? days : "");

--- a/GenDateTools/Models/DateSpan.cs
+++ b/GenDateTools/Models/DateSpan.cs
@@ -135,12 +135,12 @@ namespace GenDateTools
 
         public static bool operator ==(DateSpan left, DateSpan right)
         {
-            return left.CompareTo(right) == 0;
+            return left != null && left.CompareTo(right) == 0;
         }
 
         public static bool operator !=(DateSpan left, DateSpan right)
         {
-            return left.CompareTo(right) != 0;
+            return left != null && left.CompareTo(right) != 0;
         }
 
         public static bool operator <(DateSpan left, DateSpan right)

--- a/GenDateTools/Models/DateSpan.cs
+++ b/GenDateTools/Models/DateSpan.cs
@@ -6,9 +6,9 @@ namespace GenDateTools
     {
         private const int _daysPerYear = 365;
 
-        internal int _years;
-        internal int _days;
-        internal int _totalDays;
+        private readonly int _years;
+        private readonly int _days;
+        private readonly int _totalDays;
 
         public DateSpan(int totalDays)
         {

--- a/GenDateTools/Models/DateSpan.cs
+++ b/GenDateTools/Models/DateSpan.cs
@@ -61,7 +61,7 @@ namespace GenDateTools
         public int Years => _years;
         public int TotalDays => _totalDays;
 
-        public static int Compare(DateSpan dateSpan1, DateSpan dateSpan2)
+        private static int Compare(DateSpan dateSpan1, DateSpan dateSpan2)
         {
             if (dateSpan1.TotalDays > dateSpan2.TotalDays)
             {

--- a/GenDateTools/Models/GenDate.cs
+++ b/GenDateTools/Models/GenDate.cs
@@ -33,7 +33,7 @@ namespace GenDateTools
         /// </remarks>
         public DateRangeStrategy DateRangeStrategy
         {
-            get => _dateRangeStrategy != null ? _dateRangeStrategy : DateRangeStrategy.Strategy;
+            get => _dateRangeStrategy ?? DateRangeStrategy.Strategy;
             set => _dateRangeStrategy = value;
         }
 

--- a/GenDateTools/Models/GenDate.cs
+++ b/GenDateTools/Models/GenDate.cs
@@ -106,7 +106,7 @@ namespace GenDateTools
         /// <param name="dateString">Format: string type | from date part | date type | to date part</param>
         public GenDate(IDateStringParser parser, string dateString)
         {
-            var genDate = parser.Parse(dateString);
+            GenDate genDate = parser.Parse(dateString);
             DateType = genDate.DateType;
             DateFrom = genDate.DateFrom;
             DateTo = genDate.DateTo;
@@ -303,7 +303,7 @@ namespace GenDateTools
 
         public int CompareTo(GenDate other)
         {
-            var longDate = DateLong;
+            long longDate = DateLong;
             return longDate.CompareTo(other.DateLong);
 
         }
@@ -343,7 +343,7 @@ namespace GenDateTools
         {
             unchecked
             {
-                var hashCode = (int)DateType;
+                int hashCode = (int)DateType;
                 hashCode = (hashCode * 397) ^ (DateFrom?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (DateTo?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (DatePhrase?.GetHashCode() ?? 0);
@@ -355,8 +355,8 @@ namespace GenDateTools
 
         public override string ToString()
         {
-            var typeNames = new Dictionary<int, string> { { 0, "" }, { 1, "Bef. " }, { 2, "" }, { 3, "Abt. " }, { 4, "Cal. " }, { 5, "Est. " }, { 6, "Bet. " }, { 7, "From " }, { 8, "Int. " }, { 9, "Aft. " } };
-            var rangeJoin = new Dictionary<int, string> { { 6, " - " }, { 7, " to " } };
+            Dictionary<int, string> typeNames = new Dictionary<int, string> { { 0, "" }, { 1, "Bef. " }, { 2, "" }, { 3, "Abt. " }, { 4, "Cal. " }, { 5, "Est. " }, { 6, "Bet. " }, { 7, "From " }, { 8, "Int. " }, { 9, "Aft. " } };
+            Dictionary<int, string> rangeJoin = new Dictionary<int, string> { { 6, " - " }, { 7, " to " } };
 
             if (!IsValid)
             {
@@ -376,7 +376,7 @@ namespace GenDateTools
 
         private static bool IsAboutType(GenDateType dateType)
         {
-            foreach (var aboutType in _aboutTypes)
+            foreach (GenDateType aboutType in _aboutTypes)
             {
                 if (dateType == aboutType)
                 {

--- a/GenDateTools/Models/GenDate.cs
+++ b/GenDateTools/Models/GenDate.cs
@@ -131,26 +131,26 @@ namespace GenDateTools
         /// <summary>Gets or sets the type of the date.</summary>
         /// <value>The type of the date</value>
         [DataMember]
-        public GenDateType DateType { get; set; }
+        public GenDateType DateType { get; }
 
         /// <summary>Gets or sets the from date in a date sequence.</summary>
         /// <value>The from date</value>
         [DataMember]
-        public DatePart DateFrom { get; set; }
+        public DatePart DateFrom { get; }
 
         /// <summary>Gets or sets the to date in a date sequence.</summary>
         /// <value>The to date</value>
         [DataMember]
-        public DatePart DateTo { get; set; }
+        public DatePart DateTo { get; }
 
         /// <summary>Gets or sets the date phrase.</summary>
         /// <value>Textual value of the date</value>
         [DataMember]
-        public string DatePhrase { get; set; }
+        public string DatePhrase { get; }
 
         /// <summary>Gets or sets if the date is a valid GenDate or not.</summary>
         /// <value>True or false</value>
-        public bool IsValid { get; set; }
+        public bool IsValid { get; }
 
         public long DateLong
         {

--- a/GenDateTools/Models/GenDate.cs
+++ b/GenDateTools/Models/GenDate.cs
@@ -2,6 +2,7 @@
 using GenDateTools.Parser;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace GenDateTools
@@ -362,8 +363,8 @@ namespace GenDateTools
                 return DatePhrase;
             }
 
-            var result = typeNames[(int)DateType];
-            result += DateFrom.ToString();
+            string result = typeNames[(int)DateType];
+            result += DateFrom.ToString(CultureInfo.InvariantCulture);
 
             if (DateType == GenDateType.Between || DateType == GenDateType.Period)
             {

--- a/GenDateTools/Models/GenExtension.cs
+++ b/GenDateTools/Models/GenExtension.cs
@@ -1,4 +1,6 @@
-﻿namespace GenDateTools
+﻿using System.Globalization;
+
+namespace GenDateTools
 {
     public static class GenExtension
     {
@@ -19,7 +21,7 @@
 
         public static string ToGenString(this DatePart datePart)
         {
-            return datePart.ToString();
+            return datePart.ToString(CultureInfo.InvariantCulture);
         }
 
         public static string ToGenString(this GenDate genDate)

--- a/GenDateTools/Models/GenTools.cs
+++ b/GenDateTools/Models/GenTools.cs
@@ -4,7 +4,7 @@ namespace GenDateTools
 {
     public static class GenTools
     {
-        public static Dictionary<int, string> MonthsFromNumber()
+        private static Dictionary<int, string> MonthsFromNumber()
         {
             return new Dictionary<int, string>
             {

--- a/GenDateTools/Models/GenTools.cs
+++ b/GenDateTools/Models/GenTools.cs
@@ -36,15 +36,15 @@ namespace GenDateTools
         /// <returns></returns>
         public static string GetSubString(string source, int startIndex, int length)
         {
-            var returnString = source;
+            string returnString = source;
 
             return returnString.Substring(startIndex, length);
         }
 
         private static Dictionary<TValue, TKey> Reverse<TKey, TValue>(this IDictionary<TKey, TValue> source)
         {
-            var dictionary = new Dictionary<TValue, TKey>();
-            foreach (var entry in source)
+            Dictionary<TValue, TKey> dictionary = new Dictionary<TValue, TKey>();
+            foreach (KeyValuePair<TKey, TValue> entry in source)
             {
                 if (!dictionary.ContainsKey(entry.Value))
                 {
@@ -56,10 +56,10 @@ namespace GenDateTools
 
         private static Dictionary<string, int> ReverseUpper(this IDictionary<int, string> source)
         {
-            var dictionary = new Dictionary<string, int>();
-            foreach (var entry in source)
+            Dictionary<string, int> dictionary = new Dictionary<string, int>();
+            foreach (KeyValuePair<int, string> entry in source)
             {
-                var entryUpper = entry.Value.ToString().ToUpper();
+                string entryUpper = entry.Value.ToUpperInvariant();
 
                 if (!dictionary.ContainsKey(entryUpper))
                 {

--- a/GenDateTools/Parser/DateStringParser.cs
+++ b/GenDateTools/Parser/DateStringParser.cs
@@ -6,7 +6,7 @@ namespace GenDateTools.Parser
     {
         public virtual GenDate Parse(string dateString)
         {
-            if (dateString.Length >= 18)
+            if (dateString.Length < 18)
             {
                 return new GenDate(GenDateType.Invalid, dateString, false);
             }
@@ -19,11 +19,8 @@ namespace GenDateTools.Parser
             DatePart fromDate = GetDatePartFromStringDate(dateString.Substring(1, 8));
             DatePart toDate = GetDatePartFromStringDate(dateString.Substring(10, 8));
 
-                    return new GenDate(dateTypeOut, fromDate, toDate, true);
-                }
-            }
+            return new GenDate(dateTypeOut, fromDate, toDate, true);
 
-            return new GenDate(GenDateType.Invalid, dateString, false);
         }
 
         public virtual DatePart GetDatePartFromStringDate(string sDate)

--- a/GenDateTools/Parser/DateStringParser.cs
+++ b/GenDateTools/Parser/DateStringParser.cs
@@ -8,10 +8,16 @@ namespace GenDateTools.Parser
         {
             if (dateString.Length >= 18)
             {
-                if (Enum.TryParse(dateString.Substring(9, 1), out GenDateType dateTypeOut))
-                {
-                    var fromDate = GetDatePartFromStringDate(dateString.Substring(1, 8));
-                    var toDate = GetDatePartFromStringDate(dateString.Substring(10, 8));
+                return new GenDate(GenDateType.Invalid, dateString, false);
+            }
+
+            if (!Enum.TryParse(dateString.Substring(9, 1), out GenDateType dateTypeOut))
+            {
+                return new GenDate(GenDateType.Invalid, dateString, false);
+            }
+
+            DatePart fromDate = GetDatePartFromStringDate(dateString.Substring(1, 8));
+            DatePart toDate = GetDatePartFromStringDate(dateString.Substring(10, 8));
 
                     return new GenDate(dateTypeOut, fromDate, toDate, true);
                 }

--- a/GenDateTools/Parser/GedcomDateStringParser.cs
+++ b/GenDateTools/Parser/GedcomDateStringParser.cs
@@ -58,7 +58,7 @@ namespace GenDateTools.Parser
             {
                 string modVal = mTextMatch.Groups["mod"].Value.ToUpperInvariant();
 
-                if (_modTextType.ContainsKey(modVal) && Enum.TryParse(_modTextType[modVal].ToString().ToUpper(), out GenDateType dateType))
+                if (_modTextType.ContainsKey(modVal) && Enum.TryParse(_modTextType[modVal].ToString().ToUpperInvariant(), out GenDateType dateType))
                 {
                     DatePart date = GetDatePartFromStringDate(mTextMatch.Groups["date"].Value.ToUpperInvariant());
                     string datePhrase = mTextMatch.Groups["text"].Value;

--- a/GenDateTools/Parser/GedcomDateStringParser.cs
+++ b/GenDateTools/Parser/GedcomDateStringParser.cs
@@ -31,68 +31,68 @@ namespace GenDateTools.Parser
 
         public override GenDate Parse(string dateString)
         {
-            var dateStringUpper = dateString.ToUpper();
+            string dateStringUpper = dateString.ToUpperInvariant();
 
             // Try to match a range
-            var rMatch = _regexRange.Match(dateStringUpper);
+            Match rMatch = _regexRange.Match(dateStringUpper);
             if (rMatch.Success)
             {
-                var rangePreVal = rMatch.Groups["rangepre"].Value;
-                var rangeMidVal = rMatch.Groups["rangemid"].Value;
+                string rangePreVal = rMatch.Groups["rangepre"].Value;
+                string rangeMidVal = rMatch.Groups["rangemid"].Value;
 
                 if (_rangeTypePre.ContainsKey(rangePreVal)
                     && _rangeTypeMid.ContainsKey(rangeMidVal)
                     && _rangeTypePre[rangePreVal].ToString() == _rangeTypeMid[rangeMidVal].ToString()
                     && Enum.TryParse(_rangeTypePre[rangePreVal].ToString(), out GenDateType dateType))
                 {
-                    var fromDate = GetDatePartFromStringDate(rMatch.Groups["fromdate"].Value);
-                    var toDate = GetDatePartFromStringDate(rMatch.Groups["todate"].Value);
+                    DatePart fromDate = GetDatePartFromStringDate(rMatch.Groups["fromdate"].Value);
+                    DatePart toDate = GetDatePartFromStringDate(rMatch.Groups["todate"].Value);
 
                     return new GenDate(dateType, fromDate, toDate, fromDate.IsValidDate() && toDate.IsValidDate());
                 }
             }
 
             // Try to match date with a modifier and a text
-            var mTextMatch = _regexModText.Match(dateString);
+            Match mTextMatch = _regexModText.Match(dateString);
             if (mTextMatch.Success)
             {
-                var modVal = mTextMatch.Groups["mod"].Value.ToUpper();
+                string modVal = mTextMatch.Groups["mod"].Value.ToUpperInvariant();
 
                 if (_modTextType.ContainsKey(modVal) && Enum.TryParse(_modTextType[modVal].ToString().ToUpper(), out GenDateType dateType))
                 {
-                    var date = GetDatePartFromStringDate(mTextMatch.Groups["date"].Value.ToUpper());
-                    var datePhrase = mTextMatch.Groups["text"].Value ?? string.Empty;
+                    DatePart date = GetDatePartFromStringDate(mTextMatch.Groups["date"].Value.ToUpperInvariant());
+                    string datePhrase = mTextMatch.Groups["text"].Value;
 
                     return new GenDate(dateType, date, date, datePhrase, date.IsValidDate());
                 }
             }
 
             // Try to match date with a modifier
-            var mMatch = _regexModifier.Match(dateStringUpper);
+            Match mMatch = _regexModifier.Match(dateStringUpper);
             if (mMatch.Success)
             {
-                var modVal = mMatch.Groups["mod"].Value;
+                string modVal = mMatch.Groups["mod"].Value;
 
                 if (_modifierType.ContainsKey(modVal) && Enum.TryParse(_modifierType[modVal].ToString(), out GenDateType dateType))
                 {
-                    var date = GetDatePartFromStringDate(mMatch.Groups["date"].Value);
+                    DatePart date = GetDatePartFromStringDate(mMatch.Groups["date"].Value);
 
                     return new GenDate(dateType, date, date, date.IsValidDate());
                 }
             }
 
             // A regular date
-            var exactDate = GetDatePartFromStringDate(dateStringUpper);
+            DatePart exactDate = GetDatePartFromStringDate(dateStringUpper);
             if (exactDate != DatePart.MinValue)
             {
                 return new GenDate(GenDateType.Exact, exactDate, exactDate, exactDate.IsValidDate());
             }
 
             // Try to match a phrase
-            var pMatch = _regexPhrase.Match(dateString);
+            Match pMatch = _regexPhrase.Match(dateString);
             if (pMatch.Success)
             {
-                var datePhrase = pMatch.Groups["phrase"].Value;
+                string datePhrase = pMatch.Groups["phrase"].Value;
 
                 return new GenDate(GenDateType.Invalid, datePhrase, false);
             }
@@ -104,21 +104,21 @@ namespace GenDateTools.Parser
         public override DatePart GetDatePartFromStringDate(string sDate)
         {
             // Match on day month year
-            var mDayMonYear = _regexDayMonYear.Match(sDate);
+            Match mDayMonYear = _regexDayMonYear.Match(sDate);
             if (mDayMonYear.Success && GenTools.MonthsFromName().ContainsKey(mDayMonYear.Groups["month"].Value))
             {
                 return new DatePart(mDayMonYear.Groups["year"].Value, GenTools.MonthsFromName()[mDayMonYear.Groups["month"].Value].ToString(), mDayMonYear.Groups["day"].Value);
             }
 
             // Match on month year
-            var mMonYear = _regexMonYear.Match(sDate);
+            Match mMonYear = _regexMonYear.Match(sDate);
             if (mMonYear.Success && GenTools.MonthsFromName().ContainsKey(mMonYear.Groups["month"].Value))
             {
                 return new DatePart(mMonYear.Groups["year"].Value, GenTools.MonthsFromName()[mMonYear.Groups["month"].Value].ToString(), "0");
             }
 
             // Match on year
-            var mYear = _regexYear.Match(sDate);
+            Match mYear = _regexYear.Match(sDate);
             if (mYear.Success)
             {
                 return new DatePart(mYear.Groups["year"].Value, "0", "0");

--- a/GenDateTools/Parser/GenDateParser.cs
+++ b/GenDateTools/Parser/GenDateParser.cs
@@ -5,7 +5,7 @@ namespace GenDateTools.Parser
 {
     public class GenDateParser : GedcomDateStringParser
     {
-        private static readonly Dictionary<string, int> months = new Dictionary<string, int> { { "jan", 1 }, { "feb", 2 }, { "mar", 3 }, { "mär", 3 }, { "maa", 3 }, { "apr", 4 },
+        private static readonly Dictionary<string, int> _months = new Dictionary<string, int> { { "jan", 1 }, { "feb", 2 }, { "mar", 3 }, { "mär", 3 }, { "maa", 3 }, { "apr", 4 },
             { "mai", 5 }, { "may", 5 },  { "maj", 5 },  { "mei", 5 }, { "jun", 6 }, { "jul", 7 }, { "aug", 8 }, { "sep", 9 }, {"oct", 10 },
             {"okt", 10 }, {"nov", 11 }, {"des", 12 }, {"dec", 12 }, {"dez", 12 } };
 

--- a/GenDateTools/Parser/GenDateParser.cs
+++ b/GenDateTools/Parser/GenDateParser.cs
@@ -9,22 +9,22 @@ namespace GenDateTools.Parser
             { "mai", 5 }, { "may", 5 },  { "maj", 5 },  { "mei", 5 }, { "jun", 6 }, { "jul", 7 }, { "aug", 8 }, { "sep", 9 }, {"oct", 10 },
             {"okt", 10 }, {"nov", 11 }, {"des", 12 }, {"dec", 12 }, {"dez", 12 } };
 
-        private static readonly string beginRx = "^";
-        private static readonly string endRx = "$";
-        private static readonly string sepSpaceRx = @"[\s]+";
-        private static readonly string sepIsoRx = @"-";
-        private static readonly string sepDotRx = @"\.";
-        private static readonly string dayRx = @"(?<day>\d{1,2})";
-        private static readonly string monthNumRx = @"(?<month>\d{1,2})";
-        private static readonly string monthRx = @"(?<month>" + string.Join("|", months.Keys) + ")";
-        private static readonly string yearRx = @"(?<year>\d{1,4})";
+        private const string _beginRx = "^";
+        private const string _endRx = "$";
+        private const string _sepSpaceRx = @"[\s]+";
+        private const string _sepIsoRx = @"-";
+        private const string _sepDotRx = @"\.";
+        private const string _dayRx = @"(?<day>\d{1,2})";
+        private const string _monthNumRx = @"(?<month>\d{1,2})";
+        private static readonly string _monthRx = @"(?<month>" + string.Join("|", _months.Keys) + ")";
+        private const string _yearRx = @"(?<year>\d{1,4})";
 
-        private static readonly Regex regexDayMonYear = new Regex(beginRx + dayRx + sepSpaceRx + monthRx + sepSpaceRx + yearRx + endRx);
-        private static readonly Regex regexMonYear = new Regex(beginRx + monthRx + sepSpaceRx + yearRx + endRx);
-        private static readonly Regex regexNor = new Regex(beginRx + dayRx + sepDotRx + monthNumRx + sepDotRx + yearRx + endRx);
-        private static readonly Regex regexIso = new Regex(beginRx + yearRx + sepIsoRx + monthNumRx + sepIsoRx + dayRx + endRx);
-        private static readonly Regex regexIsoMonYear = new Regex(beginRx + yearRx + sepIsoRx + monthNumRx + endRx);
-        private static readonly Regex regexYear = new Regex(beginRx + yearRx + endRx);
+        private static readonly Regex _regexDayMonYear = new Regex(_beginRx + _dayRx + _sepSpaceRx + _monthRx + _sepSpaceRx + _yearRx + _endRx);
+        private static readonly Regex _regexMonYear = new Regex(_beginRx + _monthRx + _sepSpaceRx + _yearRx + _endRx);
+        private static readonly Regex _regexNor = new Regex(_beginRx + _dayRx + _sepDotRx + _monthNumRx + _sepDotRx + _yearRx + _endRx);
+        private static readonly Regex _regexIso = new Regex(_beginRx + _yearRx + _sepIsoRx + _monthNumRx + _sepIsoRx + _dayRx + _endRx);
+        private static readonly Regex _regexIsoMonYear = new Regex(_beginRx + _yearRx + _sepIsoRx + _monthNumRx + _endRx);
+        private static readonly Regex _regexYear = new Regex(_beginRx + _yearRx + _endRx);
 
         public override GenDate Parse(string dateString)
         {

--- a/GenDateTools/Parser/GenDateParser.cs
+++ b/GenDateTools/Parser/GenDateParser.cs
@@ -39,48 +39,46 @@ namespace GenDateTools.Parser
             sDate = sDate.ToLower();
 
             // Match on day month year
-            var mDayMonYear = regexDayMonYear.Match(sDate);
-            if (mDayMonYear.Success && months.ContainsKey(mDayMonYear.Groups["month"].Value))
+            Match mDayMonYear = _regexDayMonYear.Match(sDate);
+            if (mDayMonYear.Success && _months.ContainsKey(mDayMonYear.Groups["month"].Value))
             {
-                return new DatePart(mDayMonYear.Groups["year"].Value, months[mDayMonYear.Groups["month"].Value].ToString(), mDayMonYear.Groups["day"].Value);
+                return new DatePart(mDayMonYear.Groups["year"].Value, _months[mDayMonYear.Groups["month"].Value].ToString(), mDayMonYear.Groups["day"].Value);
             }
 
             // Match on month year
-            var mMonYear = regexMonYear.Match(sDate);
-            if (mMonYear.Success && months.ContainsKey(mMonYear.Groups["month"].Value))
+            Match mMonYear = _regexMonYear.Match(sDate);
+            if (mMonYear.Success && _months.ContainsKey(mMonYear.Groups["month"].Value))
             {
-                return new DatePart(mMonYear.Groups["year"].Value, months[mMonYear.Groups["month"].Value].ToString(), "0");
+                return new DatePart(mMonYear.Groups["year"].Value, _months[mMonYear.Groups["month"].Value].ToString(), "0");
             }
 
             // Match on dd.mm.yyyy
-            var mNor = regexNor.Match(sDate);
+            Match mNor = _regexNor.Match(sDate);
             if (mNor.Success)
             {
                 return new DatePart(mNor.Groups["year"].Value, mNor.Groups["month"].Value, mNor.Groups["day"].Value);
             }
 
             // Match on ISO
-            var mIso = regexIso.Match(sDate);
+            Match mIso = _regexIso.Match(sDate);
             if (mIso.Success)
             {
                 return new DatePart(mIso.Groups["year"].Value, mIso.Groups["month"].Value, mIso.Groups["day"].Value);
             }
 
             // Match on ISO year and month
-            var mIsoYM = regexIsoMonYear.Match(sDate);
-            if (mIsoYM.Success)
+            Match mIsoYm = _regexIsoMonYear.Match(sDate);
+            if (mIsoYm.Success)
             {
-                return new DatePart(mIsoYM.Groups["year"].Value, mIsoYM.Groups["month"].Value, "0");
+                return new DatePart(mIsoYm.Groups["year"].Value, mIsoYm.Groups["month"].Value, "0");
             }
 
             // Match on year
-            var mYear = regexYear.Match(sDate);
-            if (mYear.Success)
-            {
-                return new DatePart(mYear.Groups["year"].Value, "0", "0");
-            }
-
-            return new DatePart();
+            Match mYear = _regexYear.Match(sDate);
+            
+            return mYear.Success 
+                ? new DatePart(mYear.Groups["year"].Value, "0", "0") 
+                : new DatePart();
         }
     }
 }

--- a/GenDateTools/Parser/LegacyDateStringParser.cs
+++ b/GenDateTools/Parser/LegacyDateStringParser.cs
@@ -9,7 +9,7 @@
                 return new GenDate(GenDateType.Invalid, datePhrase: "", isValid: false);
             }
 
-            var dateTypeStr = dateString.Substring(0, 1);
+            string dateTypeStr = dateString.Substring(0, 1);
             GenDateType dateType;
 
             switch (dateTypeStr)
@@ -46,9 +46,9 @@
                     break;
             }
 
-            var fromDate = GetDatePartFromStringDate(dateString.Substring(2, 8));
-            var toDate = dateType == GenDateType.Between || dateType == GenDateType.Period ? GetDatePartFromStringDate(dateString.Substring(10, 8)) : fromDate;
-            var datePhrase = dateString.Length > 18 ? dateString.Substring(19, dateString.Length - 19) : string.Empty;
+            DatePart fromDate = GetDatePartFromStringDate(dateString.Substring(2, 8));
+            DatePart toDate = dateType == GenDateType.Between || dateType == GenDateType.Period ? GetDatePartFromStringDate(dateString.Substring(10, 8)) : fromDate;
+            string datePhrase = dateString.Length > 18 ? dateString.Substring(19, dateString.Length - 19) : string.Empty;
 
             return new GenDate(dateType, fromDate, toDate, datePhrase, isValid: fromDate.IsValidDate() && toDate.IsValidDate());
         }

--- a/GenDateTools/Parser/RootsMagicDateStringParser.cs
+++ b/GenDateTools/Parser/RootsMagicDateStringParser.cs
@@ -6,7 +6,7 @@
         {
             if (dateString.Substring(0, 1) == "T")
             {
-                var datePhrase = dateString.Length > 1 ? dateString.Substring(1, dateString.Length - 1) : string.Empty;
+                string datePhrase = dateString.Length > 1 ? dateString.Substring(1, dateString.Length - 1) : string.Empty;
                 return new GenDate(GenDateType.Invalid, datePhrase, false);
             }
 
@@ -15,8 +15,8 @@
                 return new GenDate(GenDateType.Invalid, datePhrase: "", isValid: false);
             }
 
-            var dType = dateString.Substring(1, 1);
-            var dsType = dateString.Substring(12, 1);
+            string dType = dateString.Substring(1, 1);
+            string dsType = dateString.Substring(12, 1);
             GenDateType dateType;
 
             switch (dType)
@@ -53,8 +53,8 @@
                     break;
             }
 
-            var fromDate = new DatePart(dateString.Substring(3, 8));
-            var toDate = (dateType == GenDateType.Between || dateType == GenDateType.Period) ? new DatePart(dateString.Substring(14, 8)) : fromDate;
+            DatePart fromDate = new DatePart(dateString.Substring(3, 8));
+            DatePart toDate = (dateType == GenDateType.Between || dateType == GenDateType.Period) ? new DatePart(dateString.Substring(14, 8)) : fromDate;
 
             return new GenDate(dateType, fromDate, toDate, true);
         }


### PR DESCRIPTION
These members are readonly in GenDate: DateType, DateFrom, DateTo, DatePhrase, IsValid.
Null checks on operators in DatePart.
Replaced keyword var with explicit types.
Renaming variables, methods and formatting changes.
